### PR TITLE
Add containers for NFS testing

### DIFF
--- a/nfs-server/Dockerfile
+++ b/nfs-server/Dockerfile
@@ -8,6 +8,6 @@ RUN chmod +x /usr/local/bin/setup.sh && /usr/local/bin/setup.sh
 COPY start-services.sh /usr/local/bin/
 RUN chmod +x /usr/local/bin/start-services.sh
 
-EXPOSE 5432 22
+VOLUME /nfs
 
 ENTRYPOINT ["/usr/local/bin/start-services.sh"]

--- a/nfs-server/setup.ps1
+++ b/nfs-server/setup.ps1
@@ -1,0 +1,3 @@
+docker network create --driver bridge nfs_network
+docker build --no-cache  -t nfs-server .
+docker run -dit --privileged --name nfs-server --network nfs_network nfs-server

--- a/nfs-server/setup.sh
+++ b/nfs-server/setup.sh
@@ -1,0 +1,18 @@
+#!/bin/bash
+set -e
+
+# Update and install necessary packages
+apt-get update
+apt-get install -y wget gnupg lsb-release openssh-server nano less
+
+# Update package list and install  NFS
+apt-get update
+apt-get install -y nfs-kernel-server nfs-common
+
+# Configure SSH
+mkdir -p /var/run/sshd
+echo 'root:changeme' | chpasswd
+sed -i 's/#PermitRootLogin prohibit-password/PermitRootLogin yes/' /etc/ssh/sshd_config
+
+#Add directory to NFS exports
+echo "/nfs *(rw,sync,no_subtree_check,no_root_squash)" > /etc/exports

--- a/nfs-server/start-services.sh
+++ b/nfs-server/start-services.sh
@@ -1,0 +1,21 @@
+#!/bin/bash
+set -e
+
+#Start NFS server
+service rpcbind start
+service nfs-kernel-server start
+
+# Function to stop services gracefully
+stop_services() {
+    echo "Stopping services..."
+    exit 0
+}
+
+# Trap SIGTERM and SIGINT
+trap stop_services SIGTERM SIGINT
+
+# Keep the script running
+echo "Services started, waiting for signals..."
+while true; do
+    sleep 1
+done

--- a/postgres17-redhat/Dockerfile
+++ b/postgres17-redhat/Dockerfile
@@ -1,0 +1,13 @@
+FROM registry.access.redhat.com/ubi9-init
+
+ARG TZ=Etc/UTC
+
+COPY setup.sh /usr/local/bin/setup.sh
+RUN mkdir -p /nfs
+RUN chmod +x /usr/local/bin/setup.sh && /usr/local/bin/setup.sh
+COPY start-services.sh /usr/local/bin/
+RUN chmod +x /usr/local/bin/start-services.sh
+
+EXPOSE 5432 22
+
+ENTRYPOINT ["/usr/local/bin/start-services.sh"]

--- a/postgres17-redhat/setup.ps1
+++ b/postgres17-redhat/setup.ps1
@@ -1,0 +1,4 @@
+docker build --no-cache -t postgresredhat17 .
+docker run -dit --privileged --name postgresredhat17 --network nfs_network -p 5432:5432 -p 22:22 postgresredhat17
+docker cp postgresredhat17:/root/.ssh/id_rsa ./root.key
+ssh -i root.key -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null root@localhost

--- a/postgres17-redhat/setup.sh
+++ b/postgres17-redhat/setup.sh
@@ -1,0 +1,61 @@
+#!/bin/bash
+set -e
+
+# Use Redhat subscription to register container
+subscription-manager register --username changeme --password changeme
+
+# Update and install necessary packages
+dnf update -y
+dnf install -y info wget gnupg openssh-server less
+
+# Set up PostgreSQL repository
+dnf install -y https://download.postgresql.org/pub/repos/yum/reporpms/EL-9-x86_64/pgdg-redhat-repo-latest.noarch.rpm
+
+# Update package list and install PostgreSQL 17 and NFS
+dnf install -y postgresql17-server postgresql17-contrib
+dnf -y install nfs-utils
+
+# Configure SSH
+mkdir -p /var/run/sshd
+echo 'root:changeme' | chpasswd
+
+# Configure PostgreSQL
+su - postgres -c "/usr/pgsql-17/bin/initdb -D /var/lib/pgsql/17/data"
+sed -i "s/#listen_addresses = 'localhost'/listen_addresses = '*'/" /var/lib/pgsql/17/data/postgresql.conf
+sed -i "s/#log_destination = 'stderr'/log_destination = 'csvlog'/" /var/lib/pgsql/17/data/postgresql.conf
+sed -i "s/#logging_collector = off/logging_collector = on/" /var/lib/pgsql/17/data/postgresql.conf
+sed -i "s/#track_io_timing = off/track_io_timing = on/" /var/lib/pgsql/17/data/postgresql.conf
+sed -i "s/#shared_preload_libraries = ''/shared_preload_libraries = 'pg_stat_statements, auto_explain'/" /var/lib/pgsql/17/data/postgresql.conf
+sed -i "s/local   all             postgres                                peer/local   all             postgres                                trust/" /var/lib/pgsql/17/data/pg_hba.conf
+echo "host    all             all             0.0.0.0/0               scram-sha-256" >> /var/lib/pgsql/17/data/pg_hba.conf
+echo "host    all             all             ::/0                    scram-sha-256" >> /var/lib/pgsql/17/data/pg_hba.conf
+
+# Configure auto_explain
+echo "
+auto_explain.log_format = 'json'
+auto_explain.log_level = 'log'
+auto_explain.log_verbose = 'on'
+auto_explain.log_analyze = 'on'
+auto_explain.log_buffers = 'on'
+auto_explain.log_wal = 'on'
+auto_explain.log_timing = 'on'
+auto_explain.log_triggers = 'on'
+auto_explain.sample_rate = 0.01
+auto_explain.log_min_duration = 30000
+auto_explain.log_nested_statements = 'on'
+" >> /var/lib/pgsql/17/data/postgresql.conf
+
+# Generate SSH keys
+ssh-keygen -q -m PEM -t rsa -b 4096 -f /root/.ssh/id_rsa -N ''
+cat /root/.ssh/id_rsa.pub >> /root/.ssh/authorized_keys
+
+# Start PostgreSQL and configure it
+su - postgres -c "/usr/pgsql-17/bin/pg_ctl -D /var/lib/pgsql/17/data/ -l logfile start"
+su - postgres -c "psql -c \"ALTER USER postgres WITH PASSWORD 'changeme';\""
+su - postgres -c "psql -c \"CREATE EXTENSION pg_stat_statements;\""
+
+# Revert PostgreSQL authentication method
+sed -i "s/local   all             postgres                                trust/local   all             postgres                                peer/" /var/lib/pgsql/17/data/pg_hba.conf
+
+# Stop PostgreSQL (it will be started by the entrypoint script)
+su - postgres -c "/usr/pgsql-17/bin/pg_ctl -D /var/lib/pgsql/17/data/ stop"

--- a/postgres17-redhat/start-services.sh
+++ b/postgres17-redhat/start-services.sh
@@ -1,0 +1,37 @@
+#!/bin/bash
+set -e
+
+## Start PostgreSQL
+echo "Starting PostgreSQL..."
+su - postgres -c "/usr/pgsql-17/bin/pg_ctl -D /var/lib/pgsql/17/data/ -l logfile start"
+
+#Mount NFS
+mkdir -p /nfs/mount
+mount -o nolock -t nfs nfs-server:/nfs /nfs/mount
+
+#Setup test table on NFS filesystem in PostgreSQL
+chown postgres:postgres /nfs/mount
+chmod 700 /nfs/mount
+su postgres -c "psql -c \"CREATE TABLESPACE testspace LOCATION '/nfs/mount';\""
+su postgres -c "psql -c \"CREATE TABLE test_nfs_table (id serial PRIMARY KEY, data text) TABLESPACE testspace;\""
+
+#Start SSH
+echo "Starting SSH..."
+ssh-keygen -A
+/usr/sbin/sshd 
+
+#Function to stop services gracefully
+stop_services() {
+   echo "Stopping services..."
+   su postgres -c "/usr/lib/postgresql/17/bin/pg_ctl -D /var/lib/postgresql/17/main stop"
+   exit 0
+}
+
+#Trap SIGTERM and SIGINT
+trap stop_services SIGTERM SIGINT
+
+# Keep the script running
+echo "Services started, waiting for signals..."
+while true; do
+    sleep 1
+done

--- a/postgres17-suse/Dockerfile
+++ b/postgres17-suse/Dockerfile
@@ -1,0 +1,13 @@
+FROM registry.suse.com/suse/sle15:15.6
+
+ARG TZ=Etc/UTC
+
+COPY setup.sh /usr/local/bin/setup.sh
+RUN mkdir -p /nfs
+RUN chmod +x /usr/local/bin/setup.sh && /usr/local/bin/setup.sh
+COPY start-services.sh /usr/local/bin/
+RUN chmod +x /usr/local/bin/start-services.sh
+
+EXPOSE 5432 22
+
+ENTRYPOINT ["/usr/local/bin/start-services.sh"]

--- a/postgres17-suse/setup.ps1
+++ b/postgres17-suse/setup.ps1
@@ -1,0 +1,4 @@
+docker build --no-cache -t postgressuse17 .
+docker run -dit --privileged --name postgressuse17 --network nfs_network -p 5432:5432 -p 22:22 postgressuse17
+docker cp postgressuse17:/root/.ssh/id_rsa ./root.key
+ssh -i root.key -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null root@localhost

--- a/postgres17-suse/setup.sh
+++ b/postgres17-suse/setup.sh
@@ -1,0 +1,60 @@
+#!/bin/bash
+set -e
+
+# Update and install necessary packages
+zypper update -y
+zypper install -y info wget gnupg lsb-release openssh less
+
+# Set up PostgreSQL repository
+wget --quiet -O /tmp/RPM-GPG-KEY-PGDG https://download.postgresql.org/pub/repos/yum/keys/RPM-GPG-KEY-PGDG && rpm --import /tmp/RPM-GPG-KEY-PGDG && rm /tmp/RPM-GPG-KEY-PGDG
+zypper ar -f --no-gpgcheck https://download.postgresql.org/pub/repos/zypp/17/suse/sles-15.6-x86_64/ PostgreSQL17
+zypper ref
+
+# Update package list and install PostgreSQL 17 and NFS
+zypper install -y postgresql17-server postgresql17-contrib nfs-utils gawk util-linux-systemd
+
+# Configure SSH
+mkdir -p /var/run/sshd
+echo 'root:changeme' | chpasswd
+sed -i 's/#PermitRootLogin prohibit-password/PermitRootLogin yes/' /etc/ssh/sshd_config
+
+# Configure PostgreSQL
+su - postgres -c "/usr/pgsql-17/bin/initdb -D /var/lib/pgsql/17/data/"
+sed -i "s/#listen_addresses = 'localhost'/listen_addresses = '*'/" /var/lib/pgsql/17/data/postgresql.conf
+sed -i "s/#log_destination = 'stderr'/log_destination = 'csvlog'/" /var/lib/pgsql/17/data/postgresql.conf
+sed -i "s/#logging_collector = off/logging_collector = on/" /var/lib/pgsql/17/data/postgresql.conf
+sed -i "s/#track_io_timing = off/track_io_timing = on/" /var/lib/pgsql/17/data/postgresql.conf
+sed -i "s/#shared_preload_libraries = ''/shared_preload_libraries = 'pg_stat_statements, auto_explain'/" /var/lib/pgsql/17/data/postgresql.conf
+sed -i "s/local   all             postgres                                peer/local   all             postgres                                trust/" /var/lib/pgsql/17/data/pg_hba.conf
+echo "host    all             all             0.0.0.0/0               scram-sha-256" >> /var/lib/pgsql/17/data/pg_hba.conf
+echo "host    all             all             ::/0                    scram-sha-256" >> /var/lib/pgsql/17/data/pg_hba.conf
+
+# Configure auto_explain
+echo "
+auto_explain.log_format = 'json'
+auto_explain.log_level = 'log'
+auto_explain.log_verbose = 'on'
+auto_explain.log_analyze = 'on'
+auto_explain.log_buffers = 'on'
+auto_explain.log_wal = 'on'
+auto_explain.log_timing = 'on'
+auto_explain.log_triggers = 'on'
+auto_explain.sample_rate = 0.01
+auto_explain.log_min_duration = 30000
+auto_explain.log_nested_statements = 'on'
+" >> /var/lib/pgsql/17/data/postgresql.conf
+
+# Generate SSH keys
+ssh-keygen -q -m PEM -t rsa -b 4096 -f /root/.ssh/id_rsa -N ''
+cat /root/.ssh/id_rsa.pub >> /root/.ssh/authorized_keys
+
+# Start PostgreSQL and configure it
+su - postgres -c "/usr/pgsql-17/bin/pg_ctl -D /var/lib/pgsql/17/data/ -l logfile start"
+su - postgres -c "psql -c \"ALTER USER postgres WITH PASSWORD 'changeme';\""
+su - postgres -c "psql -c \"CREATE EXTENSION pg_stat_statements;\""
+
+# Revert PostgreSQL authentication method
+sed -i "s/local   all             postgres                                trust/local   all             postgres                                peer/" /var/lib/pgsql/17/data/pg_hba.conf
+
+# Stop PostgreSQL (it will be started by the entrypoint script)
+su - postgres -c "/usr/pgsql-17/bin/pg_ctl -D /var/lib/pgsql/17/data/ stop"

--- a/postgres17-suse/start-services.sh
+++ b/postgres17-suse/start-services.sh
@@ -1,0 +1,37 @@
+#!/bin/bash
+set -e
+
+## Start PostgreSQL
+echo "Starting PostgreSQL..."
+su - postgres -c "/usr/pgsql-17/bin/pg_ctl -D /var/lib/pgsql/17/data/ -l logfile start"
+
+#Mount NFS
+mkdir -p /nfs/mount
+mount -o nolock -t nfs nfs-server:/nfs /nfs/mount
+
+#Setup test table on NFS filesystem in PostgreSQL
+chown postgres:postgres /nfs/mount
+chmod 700 /nfs/mount
+su postgres -c "psql -c \"CREATE TABLESPACE testspace LOCATION '/nfs/mount';\""
+su postgres -c "psql -c \"CREATE TABLE test_nfs_table (id serial PRIMARY KEY, data text) TABLESPACE testspace;\""
+
+#Start SSH
+echo "Starting SSH..."
+ssh-keygen -A
+"/usr/sbin/sshd" 
+
+#Function to stop services gracefully
+stop_services() {
+   echo "Stopping services..."
+   su postgres -c "/usr/lib/postgresql/17/bin/pg_ctl -D /var/lib/postgresql/17/main stop"
+   exit 0
+}
+
+#Trap SIGTERM and SIGINT
+trap stop_services SIGTERM SIGINT
+
+# Keep the script running
+echo "Services started, waiting for signals..."
+while true; do
+    sleep 1
+done

--- a/postgres17-ubuntu/Dockerfile
+++ b/postgres17-ubuntu/Dockerfile
@@ -3,9 +3,12 @@ FROM ubuntu:latest
 ARG TZ=Etc/UTC
 
 COPY setup.sh /usr/local/bin/
+RUN mkdir -p /nfs
 RUN chmod +x /usr/local/bin/setup.sh && /usr/local/bin/setup.sh
 COPY start-services.sh /usr/local/bin/
 RUN chmod +x /usr/local/bin/start-services.sh
+
+VOLUME /nfs
 
 EXPOSE 5432 22
 

--- a/postgres17-ubuntu/setup.ps1
+++ b/postgres17-ubuntu/setup.ps1
@@ -1,4 +1,4 @@
 docker build --no-cache  -t postgresubuntu17 .
-docker run -dit --name postgresubuntu17 -p 5432:5432 -p 22:22 postgresubuntu17
+docker run -dit --privileged --name postgresubuntu17 -p 5432:5432 -p 22:22 postgresubuntu17 
 docker cp postgresubuntu17:/root/.ssh/id_rsa ./root.key
 ssh -i root.key -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null root@localhost

--- a/postgres17-ubuntu/setup.ps1
+++ b/postgres17-ubuntu/setup.ps1
@@ -1,4 +1,4 @@
 docker build --no-cache  -t postgresubuntu17 .
-docker run -dit --privileged --name postgresubuntu17 -p 5432:5432 -p 22:22 postgresubuntu17 
+docker run -dit --privileged --name postgresubuntu17 --network nfs_network -p 5432:5432 -p 22:22 postgresubuntu17 
 docker cp postgresubuntu17:/root/.ssh/id_rsa ./root.key
 ssh -i root.key -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null root@localhost

--- a/postgres17-ubuntu/setup.sh
+++ b/postgres17-ubuntu/setup.sh
@@ -43,9 +43,6 @@ auto_explain.log_min_duration = 30000
 auto_explain.log_nested_statements = 'on'
 " >> /etc/postgresql/17/main/postgresql.conf
 
-#Add directory to NFS exports
-echo "/nfs *(rw,sync,no_subtree_check,no_root_squash)" > /etc/exports
-
 # Generate SSH keys
 ssh-keygen -q -m PEM -t rsa -b 4096 -f /root/.ssh/id_rsa -N ''
 cat /root/.ssh/id_rsa.pub >> /root/.ssh/authorized_keys

--- a/postgres17-ubuntu/setup.sh
+++ b/postgres17-ubuntu/setup.sh
@@ -9,9 +9,9 @@ apt-get install -y wget gnupg lsb-release openssh-server nano less
 sh -c 'echo "deb http://apt.postgresql.org/pub/repos/apt $(lsb_release -cs)-pgdg main" > /etc/apt/sources.list.d/pgdg.list'
 wget --quiet -O - https://www.postgresql.org/media/keys/ACCC4CF8.asc | apt-key add -
 
-# Update package list and install PostgreSQL 17
+# Update package list and install PostgreSQL 17 and NFS
 apt-get update
-apt-get install -y postgresql-17
+apt-get install -y postgresql-17 nfs-kernel-server nfs-common
 
 # Configure SSH
 mkdir -p /var/run/sshd
@@ -42,6 +42,9 @@ auto_explain.sample_rate = 0.01
 auto_explain.log_min_duration = 30000
 auto_explain.log_nested_statements = 'on'
 " >> /etc/postgresql/17/main/postgresql.conf
+
+#Add directory to NFS exports
+echo "/nfs *(rw,sync,no_subtree_check,no_root_squash)" > /etc/exports
 
 # Generate SSH keys
 ssh-keygen -q -m PEM -t rsa -b 4096 -f /root/.ssh/id_rsa -N ''

--- a/postgres17-ubuntu/start-services.sh
+++ b/postgres17-ubuntu/start-services.sh
@@ -15,6 +15,20 @@ if ! su postgres -c "/usr/lib/postgresql/17/bin/pg_ctl -D /var/lib/postgresql/17
     tail -n 20 /var/log/postgresql/postgresql-17-main.log
 fi
 
+#Start NFS server
+service rpcbind start
+service nfs-kernel-server start
+
+#Mount NFS
+mkdir -p /nfs/mount
+mount -t nfs localhost:/nfs /nfs/mount
+
+#Setup test table on NFS filesystem in PostgreSQL
+chown postgres:postgres /nfs/mount
+chmod 700 /nfs/mount
+su postgres -c "psql -c \"CREATE TABLESPACE testspace LOCATION '/nfs/mount';\""
+su postgres -c "psql -c \"CREATE TABLE test_nfs_table (id serial PRIMARY KEY, data text) TABLESPACE testspace;\""
+
 # Function to stop services gracefully
 stop_services() {
     echo "Stopping services..."

--- a/postgres17-ubuntu/start-services.sh
+++ b/postgres17-ubuntu/start-services.sh
@@ -4,6 +4,7 @@ set -e
 # Start SSH
 echo "Starting SSH..."
 service ssh start
+service rpcbind start
 
 # Start PostgreSQL
 echo "Starting PostgreSQL..."
@@ -15,13 +16,9 @@ if ! su postgres -c "/usr/lib/postgresql/17/bin/pg_ctl -D /var/lib/postgresql/17
     tail -n 20 /var/log/postgresql/postgresql-17-main.log
 fi
 
-#Start NFS server
-service rpcbind start
-service nfs-kernel-server start
-
 #Mount NFS
 mkdir -p /nfs/mount
-mount -t nfs localhost:/nfs /nfs/mount
+mount -t nfs nfs-server:/nfs /nfs/mount
 
 #Setup test table on NFS filesystem in PostgreSQL
 chown postgres:postgres /nfs/mount


### PR DESCRIPTION
Added PostgreSQL17 containers for Suse and Redhat with an Ubuntu NFS server container. These containers will mount the NFS server into their filesystem for testing purposes.
(Might be better to merge this into a separate 'nfs' branch instead of main)